### PR TITLE
Add an initial GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: AvaloniaUI Basics Continuous Integration
+run-name: ${{ github.actor }} triggered CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        dotnet-version: ["9.0"]
+
+    steps:
+      - run: echo "job triggered by ${{ github.event_name }}"
+      - run: echo "job running on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: List files in the repo
+        run: |
+          ls ${{ github.workspace }}


### PR DESCRIPTION
This PR adds a placeholder workflow for later adjustments and to enable the proper configuration of branch protection rules for the `main` branch.